### PR TITLE
add npm install

### DIFF
--- a/docs/05-deploy-applications-by-cdk/README.md
+++ b/docs/05-deploy-applications-by-cdk/README.md
@@ -93,6 +93,8 @@ Open the AWS Codebuild console, and click the **Create build project**, we will 
 ```shell script
 cd deployment/coffeeshop-cdk
 
+npm install
+
 npm run build 
 
 cdk synth


### PR DESCRIPTION
I had to add `npm install` otherwise `npm run build` failed with:

```
bin/coffeeshop-cdk.ts:2:22 - error TS2307: Cannot find module '@aws-cdk/core'.

2 import cdk = require('@aws-cdk/core');
                       ~~~~~~~~~~~~~~~

bin/coffeeshop-cdk.ts:9:49 - error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i @types/node`.

9     region: app.node.tryGetContext('region') || process.env.CDK_INTEG_REGION || process.env.CDK_DEFAULT_REGION,
                                                  ~~~~~~~
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
